### PR TITLE
Included socket path and permission variables in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ redis_tcp_keepalive: 0
 # Max connected clients at a time
 redis_maxclients: 10000
 redis_timeout: 0
+# Socket options
+# Set socket_path to the desired path to the socket. E.g. /var/run/redis/{{ redis_port }}.sock
+redis_socket_path: false
+redis_socket_perm: 755
 
 ## Replication options
 # Set slaveof just as you would in redis.conf. (e.g. "redis01 6379")


### PR DESCRIPTION
The socket variables were not present in the README docs, and a user would not know they are options unless they check or stumble upon defaults/main.yml. Granted that most people will be using Redis over TCP, but many also use Redis as a local cache, so these settings should be present.